### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot... 
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
   pyre:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run Pyre Action
         # update with the desired version of the action (e.g. `facebook/pyre-action@v0.0.1`)
@@ -33,20 +33,20 @@ jobs:
 ## Inputs
 ### `repo-directory`
 
-**Required**, Path to the python source code you want to analyze. If you want to analyze the root of your repo, use `'./'`. The default will be to analyze the root of your repository.
+**Required**, Path to the Python source code you want to analyze. If you want to analyze the root of your repo, use `'./'`. The default will be to analyze the root of your repository.
 
 Pyre Action will look for a [`.pyre_configuration`](https://pyre-check.org/docs/configuration/#configuration-files) in the root of your `repo-directory`. If one cannot be found, a default Pyre configuration will be used.
 
 ### `requirements-path`
 
-**Required**, Path to file containing your python code's dependencies relative to `repo-directory`. The default will look for [`requirements.txt`](https://pip.pypa.io/en/latest/reference/requirements-file-format/) in the root of the directory you specified in `repo-directory`.
+**Required**, Path to file containing your Python code's dependencies relative to `repo-directory`. The default will look for [`requirements.txt`](https://pip.pypa.io/en/latest/reference/requirements-file-format/) in the root of the directory you specified in `repo-directory`.
 
 ### `version`
 Which [version](https://pypi.org/project/pyre-check/#history) of Pyre to use. Defaults to the [latest stable version of Pyre](https://pypi.org/project/pyre-check/) if the `use-nightly` flag below is also not set.
 
 ### `use-nightly`
 
-When set to `true`, the action will use the [nightly version of Pyre](https://pypi.org/project/pyre-check-nightly/) to analyze your python code. The nightly version of Pyre tends to be unstable and is not recommended unless you are adventurous. By default, the action will use the [latest stable version of Pyre](https://pypi.org/project/pyre-check/).
+When set to `true`, the action will use the [nightly version of Pyre](https://pypi.org/project/pyre-check-nightly/) to analyze your Python code. The nightly version of Pyre tends to be unstable and is not recommended unless you are adventurous. By default, the action will use the [latest stable version of Pyre](https://pypi.org/project/pyre-check/).
 
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '>=3.6'
 
@@ -94,7 +94,7 @@ runs:
 
     - name: Saving results in SARIF
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: SARIF Results
         path: ${{inputs.repo-directory}}/sarif.json


### PR DESCRIPTION
Fixes software supply chain safety warnings like on the bottom right of
https://github.com/cclauss/Personal-Digital-Assistant/actions/runs/8520371449

[Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

[Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

* https://github.com/actions/setup-python/releases
* https://github.com/actions/upload-artifact/releases
* https://github.com/github/codeql-action/releases

@arthaud @0xedward Your reviews, please.